### PR TITLE
Add `provide` sentence at the end of the file

### DIFF
--- a/eglot-hierarchy.el
+++ b/eglot-hierarchy.el
@@ -192,3 +192,6 @@ With a prefix argument, show the outgoing call hierarchy."
     ;; so we open the first level by a click.
     (goto-char (point-min))
     (widget-button-press (point))))
+
+(provide 'eglot-hierarchy)
+;;; eglot-hierarchy.el ends here


### PR DESCRIPTION
So some users who use `use-package` to manage their packages won't encounter errors.